### PR TITLE
Events: it can happen that the subscriber is deleted but never unsubscribed

### DIFF
--- a/src/events/GraphEventSubscriber.cpp
+++ b/src/events/GraphEventSubscriber.cpp
@@ -5,7 +5,7 @@
 using namespace envire::core;
 
 GraphEventSubscriber::GraphEventSubscriber(envire::core::GraphEventPublisher* pPublisher) :
-    pPublisher(pPublisher)
+    pPublisher(nullptr)
 {
     subscribe(pPublisher);
 }
@@ -17,7 +17,12 @@ GraphEventSubscriber::GraphEventSubscriber() : pPublisher(nullptr)
 void GraphEventSubscriber::subscribe(GraphEventPublisher* pPublisher)
 {
     assert(pPublisher != nullptr);
-    pPublisher->subscribe(this);
+    // unsubscribe if already subscribed
+    if(this->pPublisher != nullptr)
+        this->pPublisher->unsubscribe(this);
+    // subscribe to new publisher
+    this->pPublisher = pPublisher;
+    this->pPublisher->subscribe(this);
 }
 
 


### PR DESCRIPTION
In the current implementation it can happen that a GraphEventSubscriber is created without a parameter and later subscribed to a publisher. In this case the subscriber is never unsubscribed.

Also the GraphEventSubscriber can only be subscribed to one publisher at a time now.