### PR TITLE
Using a custom color map for breadth first search, fix for #21

### DIFF
--- a/src/graph/Graph.hpp
+++ b/src/graph/Graph.hpp
@@ -570,7 +570,16 @@ std::vector<FrameId> Graph<F,E>::getFrames(FrameId origin, FrameId target) const
     envire::core::GraphBFSVisitor <vertex_descriptor>visit(toDesc, this->graph());
     try
     {
-        boost::breadth_first_search(this->graph(), fromDesc, visitor(visit));
+        // breadth first search uses a std::vector of default_color_type as default,
+        // which is fine for graphs using boost::vecS. Since we are using listS,
+        // we need to provide a colormap:
+        std::map<vertex_descriptor, boost::default_color_type> colors;
+        auto colorMap = boost::make_assoc_property_map(colors);
+        // the alternative would be to provide a custom vertex_index_map which maps
+        // each vertex to an integer in [0, num_vertices(g))
+
+        boost::breadth_first_search(this->graph(), fromDesc,
+            visitor(visit).color_map(colorMap));
 
     }catch(const FoundFrameException &e)
     {


### PR DESCRIPTION
By default, ```breadth_first_search``` uses an ```std::vector<default_color_type>``` of size ```num_vertices(graph)``` to keep track of which vertices have already been visited. In an ```adjacency_list``` that uses ```VertexList=vecS``` this is totally fine, as in that case the ```vertex_descriptors``` are always from the continuous range ```[0, num_vertices(graph))```. But the EnvireGraph uses ```VertexList=listS```: After removing a vertex from the graph, the range of ```vertex_descriptor```s is not continuous anymore and there may exist vertices for which ```vertex_descriptor < num_vertices(graph)``` is violated -- hence the assertion failure described in #21.

One way to fix this is to provide a colormap that does not rely on continuous numbering of the vertices, e.g a ```std::map```. 
I'm not sure if this is the best choice, or if e.g. an ```std::unordered_map``` would yield better performance.

Also, there might be other places where breadth_first_search (or similar algorithms) are used incorrectly, I just cared to fix the error I encountered. :wink:

See also: http://www.boost.org/doc/libs/1_64_0/libs/graph/doc/breadth_first_search.html
Under "Named Parameters", the descriptions of ```color_map``` and ```vertex_index_map``` are quite useful.