### PR TITLE
add clone function for templated items

### DIFF
--- a/src/items/Item.hpp
+++ b/src/items/Item.hpp
@@ -83,6 +83,20 @@ namespace envire { namespace core
             spatio_temporal_data.data = std::move(item.spatio_temporal_data.data);
         }
 
+        //https://stackoverflow.com/questions/12255546/c-deep-copying-a-base-class-pointer
+        virtual ItemBase::Ptr clone(bool keep_id = false, bool keep_frame = false) const {
+            //has to use this constructor, derived items need default constructor otherwise
+            ItemBase::Ptr ptr = ItemBase::Ptr(new Item<_ItemData>(this->getData()));
+            ptr->setTime(this->getTime());
+            if (keep_id){
+                ptr->setID(this->getID());
+            }
+            if (keep_frame){
+                ptr->setFrame(this->getFrame());
+            }
+            return ptr;
+        }
+
         virtual ~Item() {}
 
         Item<_ItemData>& operator=(const Item<_ItemData>& item)

--- a/src/items/ItemBase.hpp
+++ b/src/items/ItemBase.hpp
@@ -59,6 +59,7 @@ namespace envire { namespace core
         ItemBase(const ItemBase& item);
         ItemBase(ItemBase&& item);
         virtual ~ItemBase() {}
+        virtual ItemBase::Ptr clone(bool keep_id = false, bool keep_frame = false) const = 0;
 
         ItemBase& operator=(const ItemBase& item);
         ItemBase& operator=(ItemBase&& item);


### PR DESCRIPTION
Uses the copy constructor of the tempate class to create a deep copy of the item base pointer

I have to put  ItemBase::Ptr in a queue to be handled, meanwhile the original item in the graph might be changed

If anyone implements the ItemBase directly, whithout using the templated Item.hpp, this might break some stuff because clone() is pure virtual in ItemBase