### PR TITLE
Fixes linker problem: adds the console_bridge dependency in a couple …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(Boost COMPONENTS serialization filesystem system)
+find_package(console_bridge)
 
 
 set(headers items/ItemBase.hpp
@@ -65,7 +66,7 @@ if(ENABLE_PLUGINS)
               plugin/Plugin.hpp)
   set(sources ${sources}
               plugin/ClassLoader.cpp)
-  set(deps_pkg_config ${deps_pkg_config} class_loader plugin_manager)
+  set(deps_pkg_config ${deps_pkg_config} class_loader plugin_manager console_bridge)
   
 endif()
 


### PR DESCRIPTION
…of CMake places

I think that this should not be necessary because console_bridge is a dependency of [class_loader](https://github.com/ros/class_loader/blob/melodic-devel/CMakeLists.txt). Maybe there is something missing there that makes the linker fail on the second level dependencies?

In any case, I think that it doesn't hurt. Should be merged?