### PR TITLE
Time stamp issue

### DIFF
--- a/src/graph/TransformGraph.hpp
+++ b/src/graph/TransformGraph.hpp
@@ -67,7 +67,7 @@ namespace envire { namespace core
         void updateTransform(const FrameId& origin, const FrameId& target, 
                              const Transform& tf);
 
-        void updateTranform(const edge_descriptor edge, const Transform &tf);
+        void updateTransform(const edge_descriptor edge, const Transform &tf);
         
         /**A convenience wrapper around Base::add_edge */
         void addTransform(const vertex_descriptor origin, const vertex_descriptor target,
@@ -248,12 +248,12 @@ namespace envire { namespace core
     }
 
     template <class F>
-    void TransformGraph<F>::updateTranform(const edge_descriptor edge, const Transform &tf)
+    void TransformGraph<F>::updateTransform(const edge_descriptor edge, const Transform &tf)
     {
         vertex_descriptor source_vertex = this->getSourceVertex(edge);
         vertex_descriptor target_vertex = this->getTargetVertex(edge);
 
-        updateTranform(source_vertex, target_vertex, tf);
+        updateTransform(source_vertex, target_vertex, tf);
     }
     
     template <class F>

--- a/src/items/Transform.hpp
+++ b/src/items/Transform.hpp
@@ -94,7 +94,7 @@ namespace envire { namespace core
             {
                 last_time = tf.time;
             }
-            return Transform(this->time, this->transform*tf.transform);
+            return Transform(last_time, this->transform*tf.transform);
         }
         
         Transform inverse() const


### PR DESCRIPTION
A small fix to address two bugs in envire-envire_core.

The first one seems to be a typo (updateTranform instead of updateTran**s**form).

The second one is more problematic. The Transform type does not propagate the timestamps correctly when doing a composition. The time stamp at output is always the time stamp of the left operator instead of the highest time stamp of the two. Since there is code to determine the highest time stamp, I assumed it was an error and not an expected behavior.

