### PR TITLE
[fix_build_tests] Fix tests linkage

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ if(ENABLE_PLUGINS)
     target_link_libraries(test_plugins 
                           envire_core
                           ${Boost_LIBRARIES}
-                          ${CLS_LOADER_LIBRARIES})
+                          ${class_loader_PKGCONFIG_LIBRARIES})
     
     add_test(NAME test-plugins-cxx
              COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test_plugins")


### PR DESCRIPTION
Uses the cmake variable `class_loader_PKGCONFIG_LIBRARIES` instead of `CLS_LOADER_LIBRARIES` for linking `test_plugins`.

Without this change the tests can not be built.

I have no idea why the previous variable is not anymore set as expected. 

To test, I added these two lines to the main CMakeLists.txt:

```bash
set(ROCK_TEST_ENABLED ON)
set(ENABLE_PLUGINS ON)
```

Running the test_suite passes, but the test_plugin don't.