### PR TITLE
Fix memory leak in 2D visualization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ubuntu:16.04
+      - image: ubuntu:18.04
     steps:
       - run:
           name: apt-get

--- a/viz/EnvireGraph2DStructureVisualization/EnvireGraph2DStructurWidget.cpp
+++ b/viz/EnvireGraph2DStructureVisualization/EnvireGraph2DStructurWidget.cpp
@@ -40,7 +40,7 @@ namespace envire { namespace viz {
 
 EnvireGraph2DStructurWidget::EnvireGraph2DStructurWidget(int updateIntervalMs, 
                                                          QWidget *parent)
-    : QWidget(parent), renderer(nullptr), item(nullptr), needRedraw(false),
+    : QWidget(parent), renderer(nullptr), item(nullptr), shared_renderer(nullptr), needRedraw(false),
       pauseRedraw(false), updateInterval(updateIntervalMs), runLayoutThread(true), 
       layoutThread(&EnvireGraph2DStructurWidget::layoutGraph, this)
     
@@ -127,6 +127,10 @@ void EnvireGraph2DStructurWidget::pauseToggled(bool toggled)
 void EnvireGraph2DStructurWidget::displaySvg(QSvgRenderer* r)
 {
     item->setSharedRenderer(r);
+    if (shared_renderer){
+        delete shared_renderer;
+    }
+    shared_renderer = r;
 }
 
 

--- a/viz/EnvireGraph2DStructureVisualization/EnvireGraph2DStructurWidget.hpp
+++ b/viz/EnvireGraph2DStructureVisualization/EnvireGraph2DStructurWidget.hpp
@@ -75,6 +75,7 @@ private:
     QGraphicsSvgItem* item;
     QZoomableGraphicsView* view;
 
+    QSvgRenderer* shared_renderer;
     
     std::thread graphLayoutThread;
     


### PR DESCRIPTION
This is the least invasive fix.
I tired to use a shared_ptr first, but it seems like using it is incompatible with moving it to a thread and calling invoke with it as parameter.

Nevertheless, I think on the long run not creating a new Object all the time would be better. 