### PR TITLE
PCL requires C++14 or above

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 # executed from 'project/build' with 'cmake ../'.
 cmake_minimum_required(VERSION 3.9)
 project(envire_core VERSION 0.1 DESCRIPTION "Envire Graph Core Library")
-set(ROCK_USE_CXX11 TRUE)
 find_package(Rock)
 set(ROCK_TEST_ENABLED ON CACHE BOOL "set to ON to enable the unit tests")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
The cmake setting would cause compilation with C++11 set, which apparantly doesn't work anymore (with Ubuntu 20.04 at least)